### PR TITLE
Stop unnecessary state change from profile toggle

### DIFF
--- a/bot/src/app/components/ProfileToggle.jsx
+++ b/bot/src/app/components/ProfileToggle.jsx
@@ -5,6 +5,12 @@ import { setProfileEnabled } from '../actions/profiles';
 
 class ProfileToggle extends Component {
   onSetProfile(profileName) {
+    const { currentProfile } = this.props; 
+    if (currentProfile === profileName) {
+      this.props.notify("Atleast 1 profile must be enabled");
+      return;
+    }
+
     this.props.setProfileEnabled(profileName);
   }
 


### PR DESCRIPTION
This stops profiles from being toggled if they're already enabled. This is a simple performance fix.